### PR TITLE
Make gempak a metatask

### DIFF
--- a/parm/config/gfs/config.base
+++ b/parm/config/gfs/config.base
@@ -313,6 +313,13 @@ if (( FHMAX_HF_GFS < 120 )); then
     export ILPOST=${FHOUT_GFS}
 fi
 
+# Limit bounds of goes processing
+export FHMAX_GOES=180
+export FHOUT_GOES=3
+if (( FHMAX_GOES > FHMAX_GFS )); then
+    export FHMAX_GOES=${FHMAX_GFS}
+fi
+
 # GFS restart interval in hours
 export restart_interval_gfs=12
 # NOTE: Do not set this to zero.  Instead set it to $FHMAX_GFS

--- a/scripts/exgfs_atmos_grib2_special_npoess.sh
+++ b/scripts/exgfs_atmos_grib2_special_npoess.sh
@@ -133,12 +133,9 @@ done
 ################################################################
 # Specify Forecast Hour Range F000 - F180 for GOESSIMPGRB files 
 ################################################################
-export SHOUR=0
-export FHOUR=180
-export FHINC=3
-if (( FHOUR > FHMAX_GFS )); then
-   export FHOUR="${FHMAX_GFS}"
-fi
+export SHOUR=${FHMIN_GFS}
+export FHOUR=${FHMAX_GOES}
+export FHINC=${FHOUT_GOES}
 
 #################################
 # Process GFS PGRB2_SPECIAL_POST

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -1444,12 +1444,17 @@ class GFSTasks(Tasks):
     def gempak(self):
 
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}atmos_prod'}
+        dep_dict = {'type': 'task', 'name': f'{self.cdump}atmos_prod_f#fhr#'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
+        gempak_vars = self.envars.copy()
+        gempak_dict = {'FHR3': '#fhr#'}
+        for key, value in gempak_dict.items():
+            gempak_vars.append(rocoto.create_envar(name=key, value=str(value)))
+
         resources = self.get_resource('gempak')
-        task_name = f'{self.cdump}gempak'
+        task_name = f'{self.cdump}gempak_f#fhr#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1461,13 +1466,20 @@ class GFSTasks(Tasks):
                      'maxtries': '&MAXTRIES;'
                      }
 
-        task = rocoto.create_task(task_dict)
+        fhrs = self._get_forecast_hours(self.cdump, self._configs['gempak'])
+        fhr_var_dict = {'fhr': ' '.join([f"{fhr:03d}" for fhr in fhrs])}
+
+        fhr_metatask_dict = {'task_name': f'{self.cdump}gempak',
+                             'task_dict': task_dict,
+                             'var_dict': fhr_var_dict}
+
+        task = rocoto.create_task(fhr_metatask_dict)
 
         return task
 
     def gempakmeta(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.cdump}gempak'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}gempak'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -1490,7 +1502,7 @@ class GFSTasks(Tasks):
 
     def gempakmetancdc(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.cdump}gempak'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}gempak'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -1513,7 +1525,7 @@ class GFSTasks(Tasks):
 
     def gempakncdcupapgif(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.cdump}gempak'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}gempak'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 


### PR DESCRIPTION
# Description
Converts the regular gempak job into a metatask that runs one forecast hour at a time. The forecast hour to process is exported as a zero-padded string from rocoto as `FHR3`.

This assumes gempak is needed at all forecast output times. If gempak needs fewer times, additional changes will be needed.

Refs NOAA-EMC/global-workflow#1250
In contribution to NOAA-EMC/global-workflow#2671

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Workflow generation only

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
